### PR TITLE
err shadowed in goroutine which effectively make errcheck after <-done channel useless

### DIFF
--- a/api.go
+++ b/api.go
@@ -63,7 +63,8 @@ func (c *Client) doRequestWithFiles(method string, request url.Values, response 
 
 	go func() {
 		defer close(done)
-		req, err := http.NewRequest(http.MethodPost, endpoint, r)
+		var req *http.Request
+		req, err = http.NewRequest(http.MethodPost, endpoint, r)
 		if err != nil {
 			c.logger.Error(err)
 			return


### PR DESCRIPTION
function-level `err` variable were shadowed by goroutine local variable which effectively make useless errcheck after finish of goroutine:
```go
<-done // post request is done
if err != nil {
	return err
}
```